### PR TITLE
Implemented two new configuration parameters:

### DIFF
--- a/example/ios/Runner.xcworkspace/xcshareddata/WorkspaceSettings.xcsettings
+++ b/example/ios/Runner.xcworkspace/xcshareddata/WorkspaceSettings.xcsettings
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>BuildSystemType</key>
+	<string>Original</string>
+</dict>
+</plist>

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -70,14 +70,18 @@ class _MyHomePageState extends State<MyHomePage> {
     return HiddenDrawerMenu(
       initPositionSelected: 0,
       screens: itens,
-      backgroundColorMenu: Colors.cyan,
+      isDraggable: true,
+      enablePerspective: false,
+      backgroundColorMenu: Colors.blue,
+      slideAmount: 315.0, // defaults to 275.0
+      animationDuration: 120, // default to 250
       //    iconMenuAppBar: Icon(Icons.menu),
       //    backgroundContent: DecorationImage((image: ExactAssetImage('assets/bg_news.jpg'),fit: BoxFit.cover),
       //    whithAutoTittleName: true,
       //    styleAutoTittleName: TextStyle(color: Colors.red),
       //    actionsAppBar: <Widget>[],
       //    backgroundColorContent: Colors.blue,
-      //    backgroundColorAppBar: Colors.blue,
+      backgroundColorAppBar: Colors.blue,
       //    elevationAppBar: 4.0,
       //    tittleAppBar: Center(child: Icon(Icons.ac_unit),),
       //    enableShadowItensMenu: true,

--- a/lib/controllers/hidden_drawer_controller.dart
+++ b/lib/controllers/hidden_drawer_controller.dart
@@ -20,10 +20,11 @@ class HiddenDrawerController extends ChangeNotifier {
   /// used to control of the state of the drawer
   MenuState state = MenuState.closed;
 
-  HiddenDrawerController({this.vsync})
+  HiddenDrawerController(this.vsync, animationDuration)
       : _animationController = new AnimationController(vsync: vsync) {
     _animationController
-      ..duration = const Duration(milliseconds: 350)
+      // TODO: How to make this animation duration configurable? Defaults to 250, I like it better at 120
+      ..duration = Duration(milliseconds: animationDuration)
       ..addListener(() {
         value = _animationController.value;
         notifyListeners();

--- a/lib/hidden_drawer/hidden_drawer_menu.dart
+++ b/lib/hidden_drawer/hidden_drawer_menu.dart
@@ -28,6 +28,12 @@ class HiddenDrawerMenu extends StatelessWidget {
   ///Change elevation of the AppBar
   final double elevationAppBar;
 
+  // change the amout the screen should be slided. Defaults to 275.0
+  final double slideAmount;
+
+  // change the animation duration
+  final int animationDuration;
+
   ///Change iconmenu of the AppBar
   final Widget iconMenuAppBar;
 
@@ -60,6 +66,8 @@ class HiddenDrawerMenu extends StatelessWidget {
     this.initPositionSelected = 0,
     this.backgroundColorAppBar,
     this.elevationAppBar = 4.0,
+    this.slideAmount = 275.0,
+    this.animationDuration = 250,
     this.iconMenuAppBar = const Icon(Icons.menu),
     this.backgroundMenu,
     this.backgroundColorMenu,
@@ -82,6 +90,8 @@ class HiddenDrawerMenu extends StatelessWidget {
       initPositionSelected: initPositionSelected,
       backgroundColorAppBar: backgroundColorAppBar,
       elevationAppBar: elevationAppBar,
+      slideAmount: slideAmount,
+      animationDuration: animationDuration,
       backgroundColorContent: backgroundColorContent,
       whithAutoTittleName:whithAutoTittleName,
       styleAutoTittleName: styleAutoTittleName,

--- a/lib/menu/hidden_menu.dart
+++ b/lib/menu/hidden_menu.dart
@@ -63,7 +63,7 @@ class _HiddenMenuState extends State<HiddenMenu> {
         ),
         child: Center(
             child: Container(
-              padding: EdgeInsets.only(top: 40.0,bottom: 40.0),
+              padding: EdgeInsets.only(top: 30.0,bottom: 30.0),
               decoration: BoxDecoration(
                   boxShadow: widget.enableShadowItensMenu ? [
                     new BoxShadow(

--- a/lib/simple_hidden_drawer/simple_hidden_drawer.dart
+++ b/lib/simple_hidden_drawer/simple_hidden_drawer.dart
@@ -24,6 +24,12 @@ class SimpleHiddenDrawer extends StatefulWidget {
   ///Change elevation of the AppBar
   final double elevationAppBar;
 
+  // change the amout the screen should be slided. Defaults to 275.0
+  final double slideAmount;
+
+  // change the animation duration
+  final int animationDuration;
+
   ///Change iconmenu of the AppBar
   final Widget iconMenuAppBar;
 
@@ -58,6 +64,8 @@ class SimpleHiddenDrawer extends StatefulWidget {
     this.styleAutoTittleName,
     this.backgroundColorAppBar,
     this.elevationAppBar = 4.0,
+    this.slideAmount = 275.0,
+    this.animationDuration = 250,
     this.iconMenuAppBar = const Icon(Icons.menu),
     this.actionsAppBar,
     this.tittleAppBar,
@@ -171,7 +179,7 @@ class _SimpleHiddenDrawerState extends State<SimpleHiddenDrawer> with TickerProv
 
           var animatePercent = _animationCurve.transform(snapshot.data);
 
-          final slideAmount = 275.0 * animatePercent;
+          final slideAmount = widget.slideAmount * animatePercent;
           final contentScale = 1.0 - (0.2 * animatePercent);
           var contentPerspective = 0.0;
           final cornerRadius = 10.0 * animatePercent;
@@ -226,7 +234,8 @@ class _SimpleHiddenDrawerState extends State<SimpleHiddenDrawer> with TickerProv
   void initControllerAnimation() {
 
     _controller = new HiddenDrawerController(
-      vsync: this,
+      this,
+      widget.animationDuration
     )..addListener(() {
       _bloc.controllers.setPercentAnimate(_controller.value);
     });


### PR DESCRIPTION
I added two new parameters to make this awesome menu plugin more customizable.

slideAmount that defaults to 275.0 and animationDuration that default to 250ms. (Using your original values as defaults) Both can now be configured during widget creation, to allow animation customization