### PR TITLE
Allow GestureDetector child to catch Draggable events.

### DIFF
--- a/lib/simple_hidden_drawer/animated_drawer_content.dart
+++ b/lib/simple_hidden_drawer/animated_drawer_content.dart
@@ -88,11 +88,12 @@ class _AnimatedDrawerContentState extends State<AnimatedDrawerContent> {
   }
 
   _buildContet(BoxConstraints constraints) {
-    return widget.isDraggable
-        ? GestureDetector(
-            behavior: HitTestBehavior.translucent,
-            onHorizontalDragStart: (detail) {
-              if (detail.localPosition.dx <= WIDTH_GESTURE) {
+    return GestureDetector(
+      behavior: HitTestBehavior.translucent,
+      onHorizontalDragStart: widget.isDraggable
+          ? (detail) {
+              if (widget.isDraggable &&
+                  detail.localPosition.dx <= WIDTH_GESTURE) {
                 if (widget.withPaddingTop &&
                     detail.localPosition.dy <= HEIGHT_APPBAR) {
                   return;
@@ -101,8 +102,10 @@ class _AnimatedDrawerContentState extends State<AnimatedDrawerContent> {
                   dragging = true;
                 });
               }
-            },
-            onHorizontalDragUpdate: (detail) {
+            }
+          : null,
+      onHorizontalDragUpdate: widget.isDraggable
+          ? (detail) {
               if (dragging) {
                 var globalPosition = detail.globalPosition.dx;
                 globalPosition = globalPosition < 0 ? 0 : globalPosition;
@@ -112,23 +115,30 @@ class _AnimatedDrawerContentState extends State<AnimatedDrawerContent> {
                     : (1 - position);
                 widget.controller.move(realPosition);
               }
-            },
-            onHorizontalDragEnd: (detail) {
+            }
+          : null,
+      onHorizontalDragEnd: widget.isDraggable
+          ? (detail) {
               if (dragging) {
                 widget.controller.openOrClose();
                 setState(() {
                   dragging = false;
                 });
               }
-            },
-            onTap: () {
+            }
+          : null,
+      onTap: widget.isDraggable
+          ? () {
               if (widget.controller.state == MenuState.open) {
                 widget.controller.close();
               }
-            },
-            child: widget.child,
-          )
-        : widget.child;
+            }
+          : null,
+      child: AbsorbPointer(
+        absorbing: widget.controller.state == MenuState.open,
+        child: widget.child,
+      ),
+    );
   }
 
   List<BoxShadow> _getShadow() {

--- a/lib/simple_hidden_drawer/animated_drawer_content.dart
+++ b/lib/simple_hidden_drawer/animated_drawer_content.dart
@@ -88,44 +88,47 @@ class _AnimatedDrawerContentState extends State<AnimatedDrawerContent> {
   }
 
   _buildContet(BoxConstraints constraints) {
-    return GestureDetector(
-      behavior: HitTestBehavior.translucent,
-      onHorizontalDragStart: (detail) {
-        if (widget.isDraggable && detail.localPosition.dx <= WIDTH_GESTURE) {
-          if (widget.withPaddingTop &&
-              detail.localPosition.dy <= HEIGHT_APPBAR) {
-            return;
-          }
-          this.setState(() {
-            dragging = true;
-          });
-        }
-      },
-      onHorizontalDragUpdate: (detail) {
-        if (dragging) {
-          var globalPosition = detail.globalPosition.dx;
-          globalPosition = globalPosition < 0 ? 0 : globalPosition;
-          double position = globalPosition / constraints.maxWidth;
-          var realPosition =
-              widget.typeOpen == TypeOpen.FROM_LEFT ? position : (1 - position);
-          widget.controller.move(realPosition);
-        }
-      },
-      onHorizontalDragEnd: (detail) {
-        if (dragging) {
-          widget.controller.openOrClose();
-          setState(() {
-            dragging = false;
-          });
-        }
-      },
-      onTap: () {
-        if (widget.controller.state == MenuState.open) {
-          widget.controller.close();
-        }
-      },
-      child: widget.child,
-    );
+    return widget.isDraggable
+        ? GestureDetector(
+            behavior: HitTestBehavior.translucent,
+            onHorizontalDragStart: (detail) {
+              if (detail.localPosition.dx <= WIDTH_GESTURE) {
+                if (widget.withPaddingTop &&
+                    detail.localPosition.dy <= HEIGHT_APPBAR) {
+                  return;
+                }
+                this.setState(() {
+                  dragging = true;
+                });
+              }
+            },
+            onHorizontalDragUpdate: (detail) {
+              if (dragging) {
+                var globalPosition = detail.globalPosition.dx;
+                globalPosition = globalPosition < 0 ? 0 : globalPosition;
+                double position = globalPosition / constraints.maxWidth;
+                var realPosition = widget.typeOpen == TypeOpen.FROM_LEFT
+                    ? position
+                    : (1 - position);
+                widget.controller.move(realPosition);
+              }
+            },
+            onHorizontalDragEnd: (detail) {
+              if (dragging) {
+                widget.controller.openOrClose();
+                setState(() {
+                  dragging = false;
+                });
+              }
+            },
+            onTap: () {
+              if (widget.controller.state == MenuState.open) {
+                widget.controller.close();
+              }
+            },
+            child: widget.child,
+          )
+        : widget.child;
   }
 
   List<BoxShadow> _getShadow() {


### PR DESCRIPTION
This PR is trying to solve the issue https://github.com/RafaelBarbosatec/hidden_drawer_menu/issues/40

The main idea is to avoid the GestureDetector to catch dragging events if the `isDraggable` flag is false.

Let me know what do you think and we can discuss it and create a better implementation.

Thanks.